### PR TITLE
Move validator to .env 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ node_modules
 /.tests
 __pycache__
 scripts
+
+# Exception: Do not ignore .example.env files only within the env directory
+!/env/*.example.env
+!/env/**/*.example.env

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -46,7 +46,19 @@ source venv/bin/activate
 
 `comx module register <name> <your_commune_key> --netuid 1`
 
-4) Run the validator
+4) Set the environment variables
+
+Copy the environment variable template and set the values in the `.env` file.
+
+```bash
+cp env/.example.env env/.env
+```
+
+**Using a `.env` file will override any environment variables already set.**
+
+Alternatively, if you do not want to use a `.env` file you can set the environment variables directly and pass `--ignore-config` when running the validator.
+
+5) Run the validator
 
 ```
 python src/zangief/validator/validator.py

--- a/env/.example.env
+++ b/env/.example.env
@@ -1,0 +1,5 @@
+KEY_FILE=
+IS_TESTNET=0
+
+# Validator only env variables 
+VALIDATOR_INTERVAL=600

--- a/logs/log_2024-06-06.log
+++ b/logs/log_2024-06-06.log
@@ -1,0 +1,31 @@
+2024-06-06 16:48:29.920 | INFO     | __main__:<module>:359 - Loading validator config ... 
+2024-06-06 16:48:29.921 | INFO     | __main__:<module>:371 - Connecting to Main network ... 
+2024-06-06 16:48:50.065 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for ar
+2024-06-06 16:48:56.736 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded ar (100000 records)
+2024-06-06 16:48:57.904 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for de
+2024-06-06 16:49:04.008 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded de (100000 records)
+2024-06-06 16:49:05.078 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for en
+2024-06-06 16:49:09.212 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded en (100000 records)
+2024-06-06 16:49:10.354 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for es
+2024-06-06 16:49:15.082 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded es (100000 records)
+2024-06-06 16:49:16.243 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for fa
+2024-06-06 16:49:21.505 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded fa (100000 records)
+2024-06-06 16:49:22.845 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for fr
+2024-06-06 16:49:27.746 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded fr (100000 records)
+2024-06-06 16:49:28.808 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for hi
+2024-06-06 16:49:35.138 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded hi (100000 records)
+2024-06-06 16:49:36.241 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for he
+2024-06-06 16:49:43.843 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded he (100000 records)
+2024-06-06 16:49:44.946 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for pt
+2024-06-06 16:49:49.790 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded pt (100000 records)
+2024-06-06 16:49:50.908 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for ru
+2024-06-06 16:49:57.456 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded ru (100000 records)
+2024-06-06 16:49:58.607 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for ur
+2024-06-06 16:50:04.678 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded ur (100000 records)
+2024-06-06 16:50:06.133 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for vi
+2024-06-06 16:50:11.922 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded vi (100000 records)
+2024-06-06 16:50:13.079 | INFO     | prompt_datasets.cc_100:__init__:39 - Loading dataset for zh
+2024-06-06 16:50:20.753 | INFO     | prompt_datasets.cc_100:__init__:44 - Loaded zh (100000 records)
+2024-06-06 16:50:20.754 | INFO     | __main__:<module>:382 - Running validator ... 
+2024-06-06 16:50:20.754 | INFO     | __main__:validation_loop:345 - Begin validator step ... 
+2024-06-06 16:50:56.604 | ERROR    | __main__:_get_miner_prediction:240 - Error getting miner response: The call took longer than the timeout of 20 second(s)

--- a/src/zangief/validator/config.py
+++ b/src/zangief/validator/config.py
@@ -1,15 +1,15 @@
-import configparser
-
+import os
+from dotenv import load_dotenv
 
 class Config:
-    def __init__(self, config_file):
-        if config_file is None:
-            config_file = "env/config.ini"
-        config = configparser.ConfigParser()
-        config.read(config_file)
+    def __init__(self, config_file=None, ignore_config=False):
+        # Load environment variables from the .env file if it exists. Does not override
+        # environment variables that are already set.
+        if (ignore_config == False):
+            load_dotenv(dotenv_path=config_file if config_file else 'env/.env', override=True)
+        
         self.validator = {
-            "name": config.get("validator", "name"),
-            "keyfile": config.get("validator", "keyfile"),
-            "interval": config.get("validator", "interval"),
-            "testnet": config.get("validator", "isTestnet"),
+            "keyfile": os.getenv("KEY_FILE"),
+            "interval": os.getenv("VALIDATOR_INTERVAL"),
+            "testnet": os.getenv("IS_TESTNET"),
         }

--- a/src/zangief/validator/validator.py
+++ b/src/zangief/validator/validator.py
@@ -353,15 +353,16 @@ class TranslateValidator(Module):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="transaction validator")
     parser.add_argument("--config", type=str, default=None, help="config file path")
+    parser.add_argument('--ignore-config', action='store_true', help="ignore the env file")
     args = parser.parse_args()
 
     logger.info("Loading validator config ... ")
     if args.config is None:
-        default_config_path = "env/config.ini"
+        default_config_path = "env/.env"
         config_file = default_config_path
     else:
         config_file = args.config
-    config = Config(config_file=config_file)
+    config = Config(config_file=config_file, ignore_config=args.ignore_config)  
 
     use_testnet = True if config.validator.get("testnet") == "1" else False
     if use_testnet:


### PR DESCRIPTION
Moved validator from .ini to .env file format. 

Miners/validators have the option to interchange dynamic variables using a .env file or directly setting them in the terminal. This increase consistency and simplicity.