### PR TITLE
centralized configuration in miner.py

### DIFF
--- a/docs/miners.md
+++ b/docs/miners.md
@@ -61,7 +61,7 @@ model = gpt-3.5-turbo
 6) Run the miner
 
 ```
-python src/zangief/miner/openai_miner.py
+python src/zangief/miner/miner.py --miner openai
 ```
 
 (Optional) Run with pm2 
@@ -112,7 +112,7 @@ source venv/bin/activate
 5) Run the miner
 
 ```
-python src/zangief/miner/m2m_miner.py
+python src/zangief/miner/miner.py --miner m2m
 ```
 
 (Optional) Run with pm2 

--- a/src/zangief/miner/base_miner.py
+++ b/src/zangief/miner/base_miner.py
@@ -1,16 +1,11 @@
-import os
-import argparse
 import time
 from communex.module import Module, endpoint
-from communex.key import generate_keypair
 from keylimiter import TokenBucketLimiter
 from communex.module.server import ModuleServer
 import uvicorn
 from communex.compat.key import classic_load_key
-from config import Config
 from loguru import logger
-from os.path import dirname, realpath
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 from abc import abstractmethod
 
 
@@ -35,27 +30,19 @@ class BaseMiner(Module):
 
         return {"answer": translation}
 
-    @staticmethod
-    def get_config():
-        config_file = os.path.join(f'{dirname(dirname(dirname(dirname(realpath(__file__)))))}', 'env/config.ini')
-        config = Config(config_file=config_file)
-        return config
-
     @abstractmethod
     def generate_translation(self, prompt: str, source_language: str, target_language: str):
         pass
 
     @staticmethod
     def start_miner_server(miner):
-        config_file = os.path.join(f'{dirname(dirname(dirname(dirname(realpath(__file__)))))}', 'env/config.ini')
-        config = Config(config_file=config_file)
-        key = classic_load_key(config.get_value("keyfile"))
-        url = config.get_value("url")
+        key = classic_load_key(miner.config.get_value("keyfile"))
+        url = miner.config.get_value("url")
         parsed_url = urlparse(url)
 
         refill_rate = 1 / 100
 
-        use_testnet = True if config.get_value("isTestnet") == "1" else False
+        use_testnet = True if miner.config.get_value("isTestnet") == "1" else False
         if use_testnet:
             logger.info("Connecting to TEST network ... ")
         else:

--- a/src/zangief/miner/m2m_miner.py
+++ b/src/zangief/miner/m2m_miner.py
@@ -6,9 +6,9 @@ from base_miner import BaseMiner
 
 class M2MMiner(BaseMiner):
 
-    def __init__(self):
+    def __init__(self, config):
         super().__init__()
-        config = self.get_config()
+        self.config = config
         self.model_name = config.get_value("model", "facebook/m2m100_1.2B")
         self.device = config.get_value("device", "cuda:0")
         self.max_length = config.get_value("max_length", 1024)
@@ -49,7 +49,3 @@ class M2MMiner(BaseMiner):
         )[0]
 
         return translation
-
-if __name__ == "__main__":
-    miner = M2MMiner()
-    M2MMiner.start_miner_server(miner)

--- a/src/zangief/miner/miner.py
+++ b/src/zangief/miner/miner.py
@@ -1,0 +1,21 @@
+import argparse
+from config import Config
+from m2m_miner import M2MMiner
+from openai_miner import OpenAIMiner
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="transaction validator")
+    parser.add_argument("--miner", type=str, default="openai", help="miner type")
+    parser.add_argument("--config", type=str, default="env/config.ini", help="config file path")
+    args = parser.parse_args()
+
+    config = Config(config_file=args.config)
+
+    if args.miner == "m2m":
+        miner = M2MMiner(config=config)
+        M2MMiner.start_miner_server(miner=miner)
+    elif args.miner == "openai":
+        miner = OpenAIMiner(config=config)
+        OpenAIMiner.start_miner_server(miner=miner)
+    else:
+        print("Unsupported miner")

--- a/src/zangief/miner/openai_miner.py
+++ b/src/zangief/miner/openai_miner.py
@@ -2,14 +2,12 @@ from openai import OpenAI, APIError
 from loguru import logger
 from openai.types.chat.chat_completion import ChatCompletion
 from base_miner import BaseMiner
-from config import Config
-
 
 class OpenAIMiner(BaseMiner):
 
-    def __init__(self) -> None:
+    def __init__(self, config) -> None:
         super().__init__()
-        config: Config = self.get_config()
+        self.config = config 
         self.max_tokens = int(str(config.get_value(option="max_tokens", default=1000)))
         self.temperature = config.get_value(option="temperature", default=0.1)
         self.model = str(
@@ -46,8 +44,3 @@ class OpenAIMiner(BaseMiner):
             translation = None
 
         return translation
-
-
-if __name__ == "__main__":
-    miner = OpenAIMiner()
-    OpenAIMiner.start_miner_server(miner=miner)


### PR DESCRIPTION
Config was being handled in multiple locations. Handling configuration in a single location is more scalable and less prone to errors.

All miners are executed from a central miner.py file, where the miner type is specified as a cli arg `--miner`.